### PR TITLE
Update template.tex to allow code in PDF

### DIFF
--- a/inst/rmarkdown/templates/linguistics/resources/template.tex
+++ b/inst/rmarkdown/templates/linguistics/resources/template.tex
@@ -3,6 +3,10 @@
 \documentclass[$class_options$]{Linguistics}
 \usepackage{hyperref}
 
+$if(highlighting-macros)$
+$highlighting-macros$
+$endif$
+
 $for(header-includes)$
 $header-includes$
 $endfor$


### PR DESCRIPTION
To show R code chunks and output in the PDF, needed to do this fix:

https://stackoverflow.com/questions/41052687/rstudio-pdf-knit-fails-with-environment-shaded-undefined-error

so 'Shading' environment recognized.